### PR TITLE
Fix responsive content width

### DIFF
--- a/RaspberryZero2_Portal/src/app/app.component.html
+++ b/RaspberryZero2_Portal/src/app/app.component.html
@@ -165,7 +165,7 @@
   @media screen and (max-width: 650px) {
     .content {
       flex-direction: column;
-      width: max-content;
+      width: 100%;
     }
 
     .divider {


### PR DESCRIPTION
## Summary
- prevent small-screen overflow by ensuring content uses full width in the `max-width: 650px` media query

## Testing
- `npx ng test` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68450616587483298194e2c7625c997b