### PR TITLE
Fix realtime session reuse and show transcript

### DIFF
--- a/RaspberryZero2_Portal/src/app/app.component.html
+++ b/RaspberryZero2_Portal/src/app/app.component.html
@@ -1,3 +1,17 @@
 
-<button class="call-button" (click)="startCall()">Start AI Call</button>
+<div>Session State: {{ sessionActive ? 'Active' : 'Inactive' }}</div>
+<div *ngIf="sessionActive">Session ID: {{ sessionId }}</div>
+
+<button class="call-button" (click)="startCall()" [disabled]="sessionActive">
+  Start AI Call
+</button>
+<button class="call-button" (click)="endCall()" [disabled]="!sessionActive">
+  End AI Call
+</button>
+
+<div *ngIf="transcript.length">
+  <h3>Transcript</h3>
+  <pre>{{ transcript.join('\n') }}</pre>
+</div>
+
 <router-outlet />

--- a/RaspberryZero2_Portal/src/app/app.component.ts
+++ b/RaspberryZero2_Portal/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 
 @Component({
   selector: 'app-root',
@@ -10,43 +11,59 @@ import { HttpClient, HttpClientModule } from '@angular/common/http';
 })
 export class AppComponent {
   title = 'RaspberryZero2_Portal';
+  sessionActive = false;
+  sessionId = '';
+  transcript: string[] = [];
+  private pc?: RTCPeerConnection;
+  private ephemeralKey = '';
+
   constructor(private http: HttpClient) {}
 
   async startCall(): Promise<void> {
-    let tokenResponse;
-    let EPHEMERAL_KEY;
-    this.http.get<any>('/session').subscribe({
-      next: (res) => {
-        tokenResponse = res;
-        EPHEMERAL_KEY = tokenResponse.client_secret.value;
-      },
-      error: (err) => console.error('Error starting call', err),
-    });
+    try {
+      const tokenResponse = await firstValueFrom(this.http.get<any>('/session'));
+      this.ephemeralKey = tokenResponse.client_secret.value;
+      this.sessionId = tokenResponse.id;
+    } catch (err) {
+      console.error('Error starting call', err);
+      return;
+    }
+
+    this.transcript = [];
+    this.sessionActive = true;
 
     // Create a peer connection
-    const pc = new RTCPeerConnection();
+    this.pc = new RTCPeerConnection();
 
     // Set up to play remote audio from the model
     const audioEl = document.createElement("audio");
     audioEl.autoplay = true;
-    pc.ontrack = e => audioEl.srcObject = e.streams[0];
+    this.pc.ontrack = e => audioEl.srcObject = e.streams[0];
 
     // Add local audio track for microphone input in the browser
     const ms = await navigator.mediaDevices.getUserMedia({
       audio: true
     });
-    pc.addTrack(ms.getTracks()[0]);
+    this.pc.addTrack(ms.getTracks()[0]);
 
     // Set up data channel for sending and receiving events
-    const dc = pc.createDataChannel("oai-events");
+    const dc = this.pc.createDataChannel("oai-events");
     dc.addEventListener("message", (e) => {
-      // Realtime server events appear here!
-      console.log(e);
+      try {
+        const msg = JSON.parse(e.data);
+        if (msg.delta) {
+          this.transcript.push(msg.delta);
+        } else if (msg.text) {
+          this.transcript.push(msg.text);
+        }
+      } catch {
+        this.transcript.push(e.data);
+      }
     });
 
     // Start the session using the Session Description Protocol (SDP)
-    const offer = await pc.createOffer();
-    await pc.setLocalDescription(offer);
+    const offer = await this.pc.createOffer();
+    await this.pc.setLocalDescription(offer);
 
     const baseUrl = "https://api.openai.com/v1/realtime";
     const model = "gpt-4o-mini-realtime-preview-2024-12-17";
@@ -54,7 +71,7 @@ export class AppComponent {
       method: "POST",
       body: offer.sdp,
       headers: {
-        Authorization: `Bearer ${EPHEMERAL_KEY}`,
+        Authorization: `Bearer ${this.ephemeralKey}`,
         "Content-Type": "application/sdp"
       },
     });
@@ -63,6 +80,12 @@ export class AppComponent {
       type: "answer",
       sdp: await sdpResponse.text(),
     });
-    await pc.setRemoteDescription(answer);
+    await this.pc.setRemoteDescription(answer);
+  }
+
+  endCall(): void {
+    this.pc?.close();
+    this.pc = undefined;
+    this.sessionActive = false;
   }
 }


### PR DESCRIPTION
## Summary
- refresh ephemeral key each session by awaiting `/session`
- track session state and display transcript
- allow ending the WebRTC session from the UI

## Testing
- `npm test --silent` *(fails: Chrome cannot start as root)*

------
https://chatgpt.com/codex/tasks/task_e_6847e870e89083299a88a52f2ccbe594