### PR TITLE
Add dashboard placeholders

### DIFF
--- a/RaspberryZero2_Portal/src/app/app.component.css
+++ b/RaspberryZero2_Portal/src/app/app.component.css
@@ -1,4 +1,29 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.widgets {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.widget {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  border-radius: 4px;
+}
+
 .call-button {
-  font-size: 1.2rem;
-  padding: 1rem 2rem;
+  font-size: 1rem;
+  padding: 0.5rem 1rem;
 }

--- a/RaspberryZero2_Portal/src/app/app.component.html
+++ b/RaspberryZero2_Portal/src/app/app.component.html
@@ -1,3 +1,45 @@
 
-<button class="call-button" (click)="startCall()">Start AI Call</button>
-<router-outlet />
+<div class="dashboard">
+  <header>
+    <h1>Dashboard</h1>
+    <button class="call-button" (click)="startCall()">Start AI Call</button>
+  </header>
+  <main class="widgets">
+    <section class="widget news">
+      <h2>AI News Summary</h2>
+      <p>Coming soon...</p>
+    </section>
+    <section class="widget calendar">
+      <h2>Calendar</h2>
+      <p>Google Calendar integration placeholder</p>
+    </section>
+    <section class="widget datetime">
+      <h2>Date &amp; Time</h2>
+      <p>{{ currentDate | date:'fullDate' }} {{ currentDate | date:'shortTime' }}</p>
+    </section>
+    <section class="widget agent-status">
+      <h2>AI Agent Status</h2>
+      <p>Status information will appear here</p>
+    </section>
+    <section class="widget agent-history">
+      <h2>AI Agent History</h2>
+      <p>Recent interactions will be listed here</p>
+    </section>
+    <section class="widget system-events">
+      <h2>System Events</h2>
+      <p>Logs will show up here</p>
+    </section>
+    <section class="widget links">
+      <h2>Shortcuts</h2>
+      <ul>
+        <li><a href="#">Link 1</a></li>
+        <li><a href="#">Link 2</a></li>
+      </ul>
+    </section>
+    <section class="widget wallpaper">
+      <h2>Wallpaper</h2>
+      <p>Wallpaper controls go here</p>
+    </section>
+  </main>
+  <router-outlet />
+</div>

--- a/RaspberryZero2_Portal/src/app/app.component.spec.ts
+++ b/RaspberryZero2_Portal/src/app/app.component.spec.ts
@@ -20,10 +20,10 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('RaspberryZero2_Portal');
   });
 
-  it('should render title', () => {
+  it('should render dashboard header', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, RaspberryZero2_Portal');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Dashboard');
   });
 });

--- a/RaspberryZero2_Portal/src/app/app.component.ts
+++ b/RaspberryZero2_Portal/src/app/app.component.ts
@@ -10,7 +10,11 @@ import { HttpClient, HttpClientModule } from '@angular/common/http';
 })
 export class AppComponent {
   title = 'RaspberryZero2_Portal';
-  constructor(private http: HttpClient) {}
+  currentDate = new Date();
+
+  constructor(private http: HttpClient) {
+    setInterval(() => (this.currentDate = new Date()), 1000);
+  }
 
   async startCall(): Promise<void> {
     let tokenResponse;


### PR DESCRIPTION
## Summary
- implement placeholder dashboard layout on main page
- style dashboard grid and call button
- show current date and time
- update tests for new dashboard header

## Testing
- `npm test` *(fails: Chrome cannot start without --no-sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_6847eaa205288329a6844b68b66850ac