### PR TITLE
Adjust layout for call buttons on mobile

### DIFF
--- a/RaspberryZero2_Portal/src/app/app.component.css
+++ b/RaspberryZero2_Portal/src/app/app.component.css
@@ -8,7 +8,18 @@
 header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+}
+
+.header-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.call-sidebar {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .widgets {
@@ -26,4 +37,27 @@ header {
 .call-button {
   font-size: 1rem;
   padding: 0.5rem 1rem;
+}
+
+@media (max-width: 600px) {
+  .call-sidebar {
+    flex-direction: column;
+    position: fixed;
+    top: 0;
+    right: 0;
+    background: #fff;
+    padding: 0.5rem;
+    border-left: 1px solid #ccc;
+    box-shadow: -2px 0 4px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+  }
+
+  .call-sidebar .call-button {
+    width: 100%;
+    margin-bottom: 0.5rem;
+  }
+
+  .call-sidebar .call-button:last-child {
+    margin-bottom: 0;
+  }
 }

--- a/RaspberryZero2_Portal/src/app/app.component.html
+++ b/RaspberryZero2_Portal/src/app/app.component.html
@@ -1,38 +1,41 @@
 <div class="dashboard">
   <header>
-    <h1>Dashboard</h1>
-    <div>Session State: {{ sessionActive ? "Active" : "Inactive" }}</div>
-    <div *ngIf="sessionActive">Session ID: {{ sessionId }}</div>
+    <div class="header-info">
+      <h1>Dashboard</h1>
+      <div>Session State: {{ sessionActive ? "Active" : "Inactive" }}</div>
+      <div *ngIf="sessionActive">Session ID: {{ sessionId }}</div>
 
-    <button
-      class="call-button"
-      (click)="startCall()"
-      [disabled]="sessionActive"
-    >
-      Start AI Call
-    </button>
-    <button class="call-button" (click)="endCall()" [disabled]="!sessionActive">
-      End AI Call
-    </button>
-    <button
-      class="call-button"
-      (click)="updatePortal()"
-      [disabled]="sessionActive"
-    >
-      Update Portal
-    </button>
-    <button
-      class="call-button"
-      (click)="deployPortal()"
-      [disabled]="sessionActive"
-    >
-      Deploy Portal
-    </button>
-
-    <div *ngIf="transcript.length">
-      <h3>Transcript</h3>
-      <pre>{{ transcript.join("\n") }}</pre>
+      <div *ngIf="transcript.length">
+        <h3>Transcript</h3>
+        <pre>{{ transcript.join("\n") }}</pre>
+      </div>
     </div>
+    <aside class="call-sidebar">
+      <button
+        class="call-button"
+        (click)="startCall()"
+        [disabled]="sessionActive"
+      >
+        Start AI Call
+      </button>
+      <button class="call-button" (click)="endCall()" [disabled]="!sessionActive">
+        End AI Call
+      </button>
+      <button
+        class="call-button"
+        (click)="updatePortal()"
+        [disabled]="sessionActive"
+      >
+        Update Portal
+      </button>
+      <button
+        class="call-button"
+        (click)="deployPortal()"
+        [disabled]="sessionActive"
+      >
+        Deploy Portal
+      </button>
+    </aside>
   </header>
   <main class="widgets">
     <section class="widget news">


### PR DESCRIPTION
## Summary
- restructure dashboard header with `header-info` and `call-sidebar`
- add responsive CSS for new sidebar layout

## Testing
- `npm test --silent` *(fails: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6858e188244083298224a81307803d11