### PR TITLE
Update shortcuts links

### DIFF
--- a/RaspberryZero2_Portal/src/app/app.component.html
+++ b/RaspberryZero2_Portal/src/app/app.component.html
@@ -68,8 +68,14 @@
     <section class="widget links">
       <h2>Shortcuts</h2>
       <ul>
-        <li><a href="#">Link 1</a></li>
-        <li><a href="#">Link 2</a></li>
+        <li><a href="https://github.com/cruzjc" target="_blank">GitHub</a></li>
+        <li><a href="https://cruzjc.github.io/" target="_blank">Website</a></li>
+        <li><a href="https://chatgpt.com/codex" target="_blank">ChatGPT Codex</a></li>
+        <li>
+          <a href="https://app.netlify.com/teams/cruzjc/projects" target="_blank"
+            >Netlify Projects</a
+          >
+        </li>
       </ul>
     </section>
     <section class="widget wallpaper">


### PR DESCRIPTION
## Summary
- replace placeholder links with GitHub, website, ChatGPT Codex, and Netlify projects links

## Testing
- `npm test --silent` *(fails: Chrome cannot start as root without --no-sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_6858ed1a841c83299e070a2738f73242